### PR TITLE
Test tweaks

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,11 +108,7 @@ function input (props) {
 
   // Join our path into an HTML array foo[bar][baz]
   var serializedName = path.map(function (s, i) {
-    if (i === 0) {
-      return s
-    } else {
-      return '[' + s + ']'
-    }
+    return i === 0 ? s : '[' + s + ']'
   }).join('')
 
   return React.createElement(

--- a/test/fixtures/dom.js
+++ b/test/fixtures/dom.js
@@ -1,0 +1,10 @@
+var jsdom = require('jsdom')
+
+// A super simple DOM ready for React to render into
+// Store this DOM and the window in global scope ready for React to access
+
+module.exports = function createDOM () {
+  global.document = jsdom.jsdom('<!doctype html><html><body></body></html>')
+  global.window = document.defaultView
+  global.navigator = { userAgent: 'node.js' }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -1,9 +1,10 @@
 var enzyme = require('enzyme')
 var formalistCompose = require('formalist-compose')
-var jsdom = require('jsdom')
 var test = require('tape')
 var React = require('react')
 var serializer = require('..')
+
+require('./fixtures/dom')()
 
 // Import various data
 var dataSimple = require('./fixtures/data.js')
@@ -12,12 +13,6 @@ var dataMany = require('./fixtures/data-many.js')
 
 var composeForm = formalistCompose.default
 var mount = enzyme.mount
-
-// A super simple DOM ready for React to render into
-// Store this DOM and the window in global scope ready for React to access
-global.document = jsdom.jsdom('<!doctype html><html><body></body></html>')
-global.window = document.defaultView
-global.navigator = {userAgent: 'node.js'}
 
 /**
  * Create a wrapper
@@ -89,7 +84,6 @@ test('it should serialize a formalist AST', function (nest) {
   })
 
   nest.test('... for fields nested in `attr` blocks', function (assert) {
-    assert.plan(2)
     var wrapper = createWrapper(dataAttr, options)
     // Names
     var expectedNames = [
@@ -107,7 +101,6 @@ test('it should serialize a formalist AST', function (nest) {
   })
 
   nest.test('... for fields nested in `many` blocks', function (assert) {
-    assert.plan(2)
     var wrapper = createWrapper(dataMany, options)
     // Names
     var expectedNames = [


### PR DESCRIPTION
Just some tiny amendments.

We don't need to define a `assert.plan(x)` at the start of a test if we're ending it with `assert.end()`. 

`assert.plan(x)` says "hey, I'm expecting x many tests and then I'll automatically end".
