### PR TITLE
Bump node deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "babel-cli": "^6.6.5",
     "babel-preset-es2015": "^6.6.0",
-    "enzyme": "2.0.0",
+    "enzyme": "2.1.0",
     "eslint": "^2.3.0",
     "eslint-config-standard": "^5.1.0",
     "eslint-config-standard-react": "2.3.0",
@@ -40,19 +40,14 @@
     "jsdom": "8.1.0",
     "react-addons-test-utils": "^0.14.7",
     "tape": "4.5.1",
-    "wr": "^1.3.1"
+    "wr": "^1.3.1",
+    "react-dom": "^0.14.8",
+    "react": "^0.14.8"
   },
   "dependencies": {
     "formalist-compose": "icelab/formalist-compose",
     "immutable": "3.7.6",
-    "react-addons-clone-with-props": "0.14.7",
+    "react-addons-clone-with-props": "0.14.8",
     "react-immutable-proptypes": "1.7.0"
-  },
-  "peerDependencies": {
-    "react-dom": "^0.14.7",
-    "react": "^0.14.7"
-  },
-  "engines": {
-    "node": ">=4.2.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,14 +40,16 @@
     "jsdom": "8.1.0",
     "react-addons-test-utils": "^0.14.7",
     "tape": "4.5.1",
-    "wr": "^1.3.1",
-    "react-dom": "^0.14.8",
-    "react": "^0.14.8"
+    "wr": "^1.3.1"
   },
   "dependencies": {
     "formalist-compose": "icelab/formalist-compose",
     "immutable": "3.7.6",
     "react-addons-clone-with-props": "0.14.8",
     "react-immutable-proptypes": "1.7.0"
+  },
+  "peerDependencies": {
+    "react-dom": "^0.14.8",
+    "react": "^0.14.8"
   }
 }


### PR DESCRIPTION
This PR bumps minor versions of the following node_modules:
- enzyme 2.2.0 => 2.2.1
- react-addons-clone-with-props 0.14.7 => 0.14.8
- react/react-dom 0.14.7 => 0.14.8
