### PR TITLE
Bumps react from 0.14.8 => 15.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "react-immutable-proptypes": "1.7.0"
   },
   "peerDependencies": {
-    "react-dom": "^0.14.8",
-    "react": "^0.14.8"
+    "react-dom": "^15.0.0",
+    "react": "^15.0.0"
   }
 }


### PR DESCRIPTION
This PR bumps react/react-dom 0.14.8 => 15.0.0

Seems to be working fine with enzyme 2.1.0 as local tests are passing.
