### PR TITLE
Many array

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -113,18 +113,18 @@ function many(props) {
   var path = assemblePath(props);
   var children = props.children;
 
-  return _react2.default.createElement('div', null, _immutable.List.isList(children) && children.count() > 0 ? children.map(function renderSet(children, setIndex) {
+  return _react2.default.createElement('div', null, _immutable.List.isList(children) && children.count() > 0 ? children.map(function renderSet(children) {
     if (_immutable.List.isList(children)) {
-      return children.map(function renderChild(child, index) {
+      return children.map(function renderChild(child) {
         return _react2.default.cloneElement(child, {
           serializedPath: path,
-          serializedIndex: setIndex
+          serializedIndex: ''
         });
       });
     } else {
       return _react2.default.cloneElement(children, {
         serializedPath: path,
-        serializedIndex: setIndex
+        serializedIndex: ''
       });
     }
   }) : _react2.default.createElement(input, {

--- a/src/index.js
+++ b/src/index.js
@@ -102,18 +102,18 @@ function many (props) {
   return React.createElement(
     'div',
     null,
-    (List.isList(children) && children.count() > 0) ? children.map(function renderSet (children, setIndex) {
+    (List.isList(children) && children.count() > 0) ? children.map(function renderSet (children) {
       if (List.isList(children)) {
-        return children.map(function renderChild (child, index) {
+        return children.map(function renderChild (child) {
           return React.cloneElement(child, {
             serializedPath: path,
-            serializedIndex: setIndex
+            serializedIndex: ''
           })
         })
       } else {
         return React.cloneElement(children, {
           serializedPath: path,
-          serializedIndex: setIndex
+          serializedIndex: ''
         })
       }
     }) : React.createElement(input, {

--- a/test/index.js
+++ b/test/index.js
@@ -2,7 +2,7 @@ import { mount } from 'enzyme'
 import composeForm from 'formalist-compose'
 import test from 'tape'
 import React from 'react'
-import serializer from '..'
+import serializer from '../src'
 
 import createDOM from './fixtures/dom'
 createDOM()
@@ -70,10 +70,10 @@ test('it should serialize a formalist AST', (nest) => {
       'section_number_field',
       'group_text_field',
       'group_number_field',
-      'many[0][many_text_field]',
-      'many[0][many_date_field]',
-      'many[1][many_text_field]',
-      'many[1][many_date_field]',
+      'many[][many_text_field]',
+      'many[][many_date_field]',
+      'many[][many_text_field]',
+      'many[][many_date_field]',
       'attr[attr_text_field]',
       'attr[attr_date_field]',
       'compound_field_text_field',
@@ -132,10 +132,10 @@ test('it should serialize a formalist AST', (nest) => {
     const wrapper = createWrapper(dataMany, options)
     // Names
     const expectedNames = [
-      'many[0][many_text_field]',
-      'many[0][many_date_field]',
-      'many[1][many_text_field]',
-      'many[1][many_date_field]'
+      'many[][many_text_field]',
+      'many[][many_date_field]',
+      'many[][many_text_field]',
+      'many[][many_date_field]'
     ]
     assertInputNames(assert, wrapper, expectedNames)
     // Values
@@ -170,10 +170,10 @@ test('it should handle namespacing prefixes', (nest) => {
       'user[section_number_field]',
       'user[group_text_field]',
       'user[group_number_field]',
-      'user[many][0][many_text_field]',
-      'user[many][0][many_date_field]',
-      'user[many][1][many_text_field]',
-      'user[many][1][many_date_field]',
+      'user[many][][many_text_field]',
+      'user[many][][many_date_field]',
+      'user[many][][many_text_field]',
+      'user[many][][many_date_field]',
       'user[attr][attr_text_field]',
       'user[attr][attr_date_field]',
       'user[compound_field_text_field]',
@@ -196,10 +196,10 @@ test('it should handle namespacing prefixes', (nest) => {
   nest.test('... for fields nested in `many` blocks', (assert) => {
     const wrapper = createWrapper(dataMany, options)
     const expectedNames = [
-      'user[many][0][many_text_field]',
-      'user[many][0][many_date_field]',
-      'user[many][1][many_text_field]',
-      'user[many][1][many_date_field]'
+      'user[many][][many_text_field]',
+      'user[many][][many_date_field]',
+      'user[many][][many_text_field]',
+      'user[many][][many_date_field]'
     ]
     assertInputNames(assert, wrapper, expectedNames)
     assert.end()


### PR DESCRIPTION
Changes the output for `many` blocks to be a normal array for a form POST.

Before:

``` html
<input type="hidden" name="many[0][title]"/>
<input type="hidden" name="many[1][title]"/>
```

After:

``` html
<input type="hidden" name="many[][title]"/>
<input type="hidden" name="many[][title]"/>
```
