### PR TITLE
Render empty list values

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -69,6 +69,10 @@ function renderValue(name, value, path) {
 }
 
 function renderList(name, value, path) {
+  // Render an empty input for a list if it contains nothing
+  if (!value || value.length === 0) {
+    return render(name, '', path);
+  }
   return value.map(function (c) {
     return render([name, ''], c, path);
   });

--- a/src/index.js
+++ b/src/index.js
@@ -55,6 +55,10 @@ function renderValue (name, value, path) {
 }
 
 function renderList (name, value, path) {
+  // Render an empty input for a list if it contains nothing
+  if (!value || value.length === 0) {
+    return render(name, '', path)
+  }
   return value.map((c) => {
     return render([name, ''], c, path)
   })


### PR DESCRIPTION
Render a value-less input if a list exists but has no content.

This is to handle cases where content has been removed from say a `many`, this would ensure that the field is included in the output with nil value instead of simply being missing.

@timriley Are there any complications you can think would arise on the ruby-side from this change?