### PR TITLE
Prepend flat junk key to output for lists containing maps

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -70,7 +70,14 @@ function renderValue(name, value, path) {
 
 function renderList(name, value, path) {
   return value.map(function (c) {
-    return render([name, ''], c, path);
+    // Insert a junk value as the _first_ item in an array where the contents of
+    // the array are a map to ensure params are parsed correctly by rack
+    // https://github.com/rack/rack/issues/951
+    if (isObject(c) || _immutable.Map.isMap(c)) {
+      return [render([name, '', '__rack_workaround'], '', path), render([name, ''], c, path)];
+    } else {
+      return render([name, ''], c, path);
+    }
   });
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -56,7 +56,17 @@ function renderValue (name, value, path) {
 
 function renderList (name, value, path) {
   return value.map((c) => {
-    return render([name, ''], c, path)
+    // Insert a junk value as the _first_ item in an array where the contents of
+    // the array are a map to ensure params are parsed correctly by rack
+    // https://github.com/rack/rack/issues/951
+    if (isObject(c) || Map.isMap(c)) {
+      return [
+        render([name, '', '__rack_workaround'], '', path),
+        render([name, ''], c, path)
+      ]
+    } else {
+      return render([name, ''], c, path);
+    }
   })
 }
 


### PR DESCRIPTION
This insert a junk value as the _first_ item in an array where the contents of the array are a map to ensure params are parsed correctly by rack: https://github.com/rack/rack/issues/951

To illustrate the problem:


```
<input name="many_foos[][user][id]" value="1">
<input name="many_foos[][user][name]" value="Jojo">
<input name="many_foos[][user][id]" value="2">
<input name="many_foos[][user][name]" value="Narinda">
<input name="many_foos[][user][id]" value="3">
<input name="many_foos[][user][name]" value="Jess">
```

Will be parsed by rack as:

```
[{"user"=>{"id"=>"3", "name"=>"Jess"}}]
```

Whereas:

```
<input name="many_foos[][_null]" value="">
<input name="many_foos[][user][id]" value="1">
<input name="many_foos[][user][name]" value="Jojo">
<input name="many_foos[][_null]" value="">
<input name="many_foos[][user][id]" value="2">
<input name="many_foos[][user][name]" value="Narinda">
<input name="many_foos[][_null]" value="">
<input name="many_foos[][user][id]" value="3">
<input name="many_foos[][user][name]" value="Jess">
```

Will be parsed by rack as:

```
[{
    "_null" => "",
    "user" => {
        "id" => "1",
        "name" => "Jojo"
    }
}, {
    "_null" => "",
    "user" => {
        "id" => "2",
        "name" => "Narinda"
    }
}, {
    "_null" => "",
    "user" => {
        "id" => "3",
        "name" => "Jess"
    }
}]
```

The the presence of the non-nested key that tells rack to start a new array correctly, instead of simply clobbering the previous item.